### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -13,6 +13,9 @@ on:
       - "**.md"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,9 @@ name: CD
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/gampig/feuerwehr-app/security/code-scanning/3](https://github.com/gampig/feuerwehr-app/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/cd-staging.yml` to restrict the `GITHUB_TOKEN` to the minimum required scope.

Best single fix (without changing functionality): define workflow-level permissions right after the trigger section (`on:`), using:

- `contents: read`

This applies to all jobs in the workflow (including `vue-client`) and is sufficient for `actions/checkout@v4`. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
